### PR TITLE
FloatingGroup support in DragPane

### DIFF
--- a/ui/src/com/kotcrab/vis/ui/layout/DragPane.java
+++ b/ui/src/com/kotcrab/vis/ui/layout/DragPane.java
@@ -529,13 +529,22 @@ public class DragPane extends Container<WidgetGroup> {
 		protected boolean addToFloatingGroup (final Draggable draggable, final Actor actor, final DragPane dragPane) {
 			final FloatingGroup group = dragPane.getFloatingGroup();
 			dragPane.stageToLocalCoordinates(DRAG_POSITION);
-			final float x = DRAG_POSITION.x + draggable.getOffsetX();
+			float x = DRAG_POSITION.x + draggable.getOffsetX();
 			if (x < 0f || x + actor.getWidth() > dragPane.getWidth()) {
-				return CANCEL;
+				// Normalizing value if set to keep within parent's bounds:
+				if (draggable.isKeptWithinParent()) {
+					x = x < 0f ? 0f : dragPane.getWidth() - actor.getWidth() - 1f;
+				} else {
+					return CANCEL;
+				}
 			}
-			final float y = DRAG_POSITION.y + draggable.getOffsetY();
+			float y = DRAG_POSITION.y + draggable.getOffsetY();
 			if (y < 0f || y + actor.getHeight() > dragPane.getHeight()) {
-				return CANCEL;
+				if (draggable.isKeptWithinParent()) {
+					y = y < 0f ? 0f : dragPane.getHeight() - actor.getHeight() - 1f;
+				} else {
+					return CANCEL;
+				}
 			}
 			actor.remove();
 			actor.setPosition(x, y);

--- a/ui/src/com/kotcrab/vis/ui/layout/DragPane.java
+++ b/ui/src/com/kotcrab/vis/ui/layout/DragPane.java
@@ -529,8 +529,16 @@ public class DragPane extends Container<WidgetGroup> {
 		protected boolean addToFloatingGroup (final Draggable draggable, final Actor actor, final DragPane dragPane) {
 			final FloatingGroup group = dragPane.getFloatingGroup();
 			dragPane.stageToLocalCoordinates(DRAG_POSITION);
+			final float x = DRAG_POSITION.x + draggable.getOffsetX();
+			if (x < 0f || x + actor.getWidth() > dragPane.getWidth()) {
+				return CANCEL;
+			}
+			final float y = DRAG_POSITION.y + draggable.getOffsetY();
+			if (y < 0f || y + actor.getHeight() > dragPane.getHeight()) {
+				return CANCEL;
+			}
 			actor.remove();
-			actor.setPosition(DRAG_POSITION.x + draggable.getOffsetX(), DRAG_POSITION.y + draggable.getOffsetY());
+			actor.setPosition(x, y);
 			group.addActor(actor);
 			return APPROVE;
 		}

--- a/ui/src/com/kotcrab/vis/ui/layout/DragPane.java
+++ b/ui/src/com/kotcrab/vis/ui/layout/DragPane.java
@@ -94,6 +94,24 @@ public class DragPane extends Container<WidgetGroup> {
 		return getActor() instanceof GridGroup;
 	}
 
+	/** @return true if children are displayed with a {@link VerticalFlowGroup}.
+	 * @see #getVerticalFlowGroup() */
+	public boolean isVerticalFlow () {
+		return getActor() instanceof VerticalFlowGroup;
+	}
+
+	/** @return true if children are displayed with a {@link HorizontalFlowGroup}.
+	 * @see #getHorizontalFlowGroup() */
+	public boolean isHorizontalFlow () {
+		return getActor() instanceof HorizontalFlowGroup;
+	}
+
+	/** @return true if children are displayed with a {@link FloatingGroup}.
+	 * @see #getFloatingGroup() */
+	public boolean isFloating () {
+		return getActor() instanceof FloatingGroup;
+	}
+
 	@Override
 	public SnapshotArray<Actor> getChildren () {
 		return getActor().getChildren();
@@ -148,6 +166,27 @@ public class DragPane extends Container<WidgetGroup> {
 	 */
 	public GridGroup getGridGroup () {
 		return (GridGroup) getActor();
+	}
+
+	/** @return internally managed group of actors.
+	 * @throws ClassCastException if drag pane is not horizontal flow.
+	 * @see #isHorizontalFlow() */
+	public HorizontalFlowGroup getHorizontalFlowGroup () {
+		return (HorizontalFlowGroup)getActor();
+	}
+
+	/** @return internally managed group of actors.
+	 * @throws ClassCastException if drag pane is not vertical flow.
+	 * @see #isVerticalFlow() */
+	public VerticalFlowGroup getVerticalFlowGroup () {
+		return (VerticalFlowGroup)getActor();
+	}
+
+	/** @return internally managed group of actors.
+	 * @throws ClassCastException if drag pane is not floating.
+	 * @see #isFloating() */
+	public FloatingGroup getFloatingGroup () {
+		return (FloatingGroup)getActor();
 	}
 
 	/** @return dragging listener automatically added to all panes' children. */
@@ -353,41 +392,52 @@ public class DragPane extends Container<WidgetGroup> {
 		}
 
 		@Override
-		public boolean onStart (final Actor actor, final float stageX, final float stageY) {
+		public boolean onStart (final Draggable draggable, final Actor actor, final float stageX, final float stageY) {
 			return APPROVE;
 		}
 
 		@Override
-		public void onDrag (final Actor actor, final float stageX, final float stageY) {
+		public void onDrag (final Draggable draggable, final Actor actor, final float stageX, final float stageY) {
 		}
 
 		@Override
-		public boolean onEnd (final Actor actor, final float stageX, final float stageY) {
+		public boolean onEnd (final Draggable draggable, final Actor actor, final float stageX, final float stageY) {
 			if (actor == null || actor.getStage() == null) {
 				return CANCEL;
 			}
 			final Actor overActor = actor.getStage().hit(stageX, stageY, true);
-			if (overActor == null || overActor == actor || overActor.isAscendantOf(actor)) {
+			if (overActor == null || overActor == actor) {
+				return CANCEL;
+			} else if (overActor.isAscendantOf(actor)) {
+				final DragPane dragPane = getDragPane(actor);
+				if (dragPane != null && dragPane.isFloating()) {
+					DRAG_POSITION.set(stageX, stageY);
+					return addToFloatingGroup(draggable, actor, dragPane);
+				}
 				return CANCEL;
 			}
 			DRAG_POSITION.set(stageX, stageY);
 			if (overActor instanceof DragPane) {
-				return addDirectlyToPane(actor, (DragPane) overActor);
+				return addDirectlyToPane(draggable, actor, (DragPane) overActor);
 			}
 			final DragPane dragPane = getDragPane(overActor);
 			if (accept(actor, dragPane)) {
-				return addActor(actor, overActor, dragPane);
+				return addActor(draggable, actor, overActor, dragPane);
 			}
 			return CANCEL;
 		}
 
 		/**
+		 * @param draggable is attached to the actor.
 		 * @param actor dragged actor.
 		 * @param dragPane is directly under the dragged actor. If accepts the actor, it should be added to its content.
 		 * @return true if actor was accepted.
 		 */
-		protected boolean addDirectlyToPane (final Actor actor, final DragPane dragPane) {
+		protected boolean addDirectlyToPane (final Draggable draggable, final Actor actor, final DragPane dragPane) {
 			if (accept(actor, dragPane)) {
+				if (dragPane.isFloating()) {
+					return addToFloatingGroup(draggable, actor, dragPane);
+				}
 				// Dragged directly to a pane. Assuming no padding, adding last:
 				dragPane.addActor(actor);
 				return APPROVE;
@@ -405,18 +455,21 @@ public class DragPane extends Container<WidgetGroup> {
 		}
 
 		/**
+		 * @param draggable is attached to the actor.
 		 * @param actor is being dragged.
 		 * @param overActor is directly under the dragged actor.
 		 * @param dragPane contains the actor under dragged widget.
 		 * @return true if actor is accepted and added to the group.
 		 */
-		protected boolean addActor (final Actor actor, final Actor overActor, final DragPane dragPane) {
+		protected boolean addActor (final Draggable draggable, final Actor actor, final Actor overActor, final DragPane dragPane) {
 			final Actor directPaneChild = getActorInDragPane(overActor, dragPane);
 			directPaneChild.stageToLocalCoordinates(DRAG_POSITION);
-			if (dragPane.isVertical()) {
+			if (dragPane.isVertical() || dragPane.isVerticalFlow()) {
 				return addToVerticalGroup(actor, dragPane, directPaneChild);
-			} else if (dragPane.isHorizontal()) {
+			} else if (dragPane.isHorizontal() || dragPane.isHorizontalFlow()) {
 				return addToHorizontalGroup(actor, dragPane, directPaneChild);
+			} else if (dragPane.isFloating()) {
+				return addToFloatingGroup(draggable, actor, dragPane);
 			} // This is the default behavior for grid and unknown groups:
 			return addToOtherGroup(actor, dragPane, directPaneChild);
 		}
@@ -466,6 +519,19 @@ public class DragPane extends Container<WidgetGroup> {
 			} else {
 				dragPane.addActorBefore(directPaneChild, actor);
 			}
+			return APPROVE;
+		}
+
+		/** @param draggable attached to dragged actor.
+		 * @param actor is being dragged.
+		 * @param dragPane is under the actor. Stores a {@link FloatingGroup}.
+		 * @return true if actor was accepted by the group. */
+		protected boolean addToFloatingGroup (final Draggable draggable, final Actor actor, final DragPane dragPane) {
+			final FloatingGroup group = dragPane.getFloatingGroup();
+			dragPane.stageToLocalCoordinates(DRAG_POSITION);
+			actor.remove();
+			actor.setPosition(DRAG_POSITION.x + draggable.getOffsetX(), DRAG_POSITION.y + draggable.getOffsetY());
+			group.addActor(actor);
 			return APPROVE;
 		}
 

--- a/ui/src/com/kotcrab/vis/ui/widget/Draggable.java
+++ b/ui/src/com/kotcrab/vis/ui/widget/Draggable.java
@@ -142,6 +142,16 @@ public class Draggable extends InputListener {
 		actor.addListener(this);
 	}
 
+	/** @return during dragging, this is the offset value on X axis from the start of the dragged widget. */
+	public float getOffsetX () {
+		return offsetX;
+	}
+
+	/** @return during dragging, this is the offset value on Y axis from the start of the dragged widget. */
+	public float getOffsetY () {
+		return offsetY;
+	}
+
 	/** @return alpha color value of dragged actor copy. */
 	public float getAlpha () {
 		return alpha;
@@ -252,7 +262,7 @@ public class Draggable extends InputListener {
 		if (!isValid(actor) || isDisabled(actor)) {
 			return false;
 		}
-		if (listener == null || listener.onStart(actor, event.getStageX(), event.getStageY())) {
+		if (listener == null || listener.onStart(this, actor, event.getStageX(), event.getStageY())) {
 			attachMimic(actor, event, x, y);
 			return true;
 		}
@@ -397,7 +407,7 @@ public class Draggable extends InputListener {
 			getStageCoordinates(event);
 			mimic.setPosition(MIMIC_COORDINATES.x, MIMIC_COORDINATES.y);
 			if (listener != null) {
-				listener.onDrag(mimic.getActor(), STAGE_COORDINATES.x, STAGE_COORDINATES.y);
+				listener.onDrag(this, mimic.getActor(), STAGE_COORDINATES.x, STAGE_COORDINATES.y);
 			}
 		}
 	}
@@ -409,7 +419,7 @@ public class Draggable extends InputListener {
 			getStageCoordinates(event);
 			mimic.setPosition(MIMIC_COORDINATES.x, MIMIC_COORDINATES.y);
 			if (listener == null || mimic.getActor().getStage() != null
-					&& listener.onEnd(mimic.getActor(), STAGE_COORDINATES.x, STAGE_COORDINATES.y)) {
+					&& listener.onEnd(this, mimic.getActor(), STAGE_COORDINATES.x, STAGE_COORDINATES.y)) {
 				// Drag end approved - fading out.
 				addMimicHidingAction(Actions.fadeOut(fadingTime, fadingInterpolation), fadingTime);
 			} else {
@@ -440,28 +450,31 @@ public class Draggable extends InputListener {
 		boolean CANCEL = false, APPROVE = true;
 
 		/**
+		 * @param draggable source of event.
 		 * @param actor is about to be dragged.
 		 * @param stageX stage coordinate on X axis where the drag started.
 		 * @param stageY stage coordinate on Y axis where the drag started.
 		 * @return if true, actor will not be dragged.
 		 */
-		boolean onStart (Actor actor, float stageX, float stageY);
+		boolean onStart (Draggable draggable, Actor actor, float stageX, float stageY);
 
 		/**
+		 * @param draggable source of event.
 		 * @param actor is being dragged.
 		 * @param stageX stage coordinate on X axis with current cursor position.
 		 * @param stageY stage coordinate on Y axis with current cursor position.
 		 */
-		void onDrag (Actor actor, float stageX, float stageY);
+		void onDrag (Draggable draggable, Actor actor, float stageX, float stageY);
 
 		/**
+		 * @param draggable source of event.
 		 * @param actor is about to stop being dragged.
 		 * @param stageX stage coordinate on X axis where the drag ends.
 		 * @param stageY stage coordinate on X axis where the drag ends.
 		 * @return if true, "mirror" of the actor will quickly fade out. If false, mirror will return to the original actor's
 		 * position.
 		 */
-		boolean onEnd (Actor actor, float stageX, float stageY);
+		boolean onEnd (Draggable draggable, Actor actor, float stageX, float stageY);
 	}
 
 	/**
@@ -471,16 +484,16 @@ public class Draggable extends InputListener {
 	 */
 	public static class DragAdapter implements DragListener {
 		@Override
-		public boolean onStart (final Actor actor, final float stageX, final float stageY) {
+		public boolean onStart (final Draggable draggable, final Actor actor, final float stageX, final float stageY) {
 			return APPROVE;
 		}
 
 		@Override
-		public void onDrag (final Actor actor, final float stageX, final float stageY) {
+		public void onDrag (final Draggable draggable, final Actor actor, final float stageX, final float stageY) {
 		}
 
 		@Override
-		public boolean onEnd (final Actor actor, final float stageX, final float stageY) {
+		public boolean onEnd (final Draggable draggable, final Actor actor, final float stageX, final float stageY) {
 			return APPROVE;
 		}
 	}


### PR DESCRIPTION
Now you can use `DragPane` along with a `FloatingGroup` to create a true drop-and-drag-anywhere powerhouse.

This might slightly affect other widgets using `DragPane` (like `TabbedPane`) - I tested it locally with `gdx-lml-vis-tests` and it seems fine, but some additional checks are welcome.

Not sure is the behavior is correct, though. I could easily add a check that disallows dragging is the actor is outside of the original FloatingGroup bounds; right now you can drag an actor near group's border, where it basically "breaks" the bounds.

Note that `Draggable$DragListener` API changed. `Draggable` was added to each method, so you can check the source of the event. Some utility methods were added to `DragPane` to support other groups.