### PR TITLE
Fix hang on scene load, when on Mac OS X

### DIFF
--- a/editor/src/com/kotcrab/vis/editor/Main.java
+++ b/editor/src/com/kotcrab/vis/editor/Main.java
@@ -42,6 +42,7 @@ public class Main {
 
 	public static void main (String[] args) throws Exception {
 		App.init();
+		if(OsUtils.isMac())System.setProperty("java.awt.headless", "true");
 
 		LaunchConfiguration launchConfig = new LaunchConfiguration();
 


### PR DESCRIPTION
When loading a scene, TexturePacker is used which loads some awt classes.
When these awt classes are loaded, the whole awt event loop is started and vis-editor is blocked.
Fix is simple, run awt in headless mode, which allows using Image related functions.