### PR TITLE
fixed window resize on osx

### DIFF
--- a/editor/src/main/java/com/kotcrab/vis/editor/Main.java
+++ b/editor/src/main/java/com/kotcrab/vis/editor/Main.java
@@ -83,6 +83,7 @@ public class Main {
 
 		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
 		config.setWindowedMode(1280, 720);
+		config.setWindowSizeLimits(1, 1, 9999, 9999);
 		config.useVsync(true);
 		config.setWindowListener(new Lwjgl3WindowAdapter() {
 			@Override


### PR DESCRIPTION
Without that, resizing the window results in 0 size window. That makes it hard to work with.