### PR TITLE
MultiSplitPane should not block content area touches

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/MultiSplitPane.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/MultiSplitPane.java
@@ -86,7 +86,11 @@ public class MultiSplitPane extends WidgetGroup {
 
 			@Override
 			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
-				return true;
+				if (getHandleContaining(x, y) != null) {
+					return true;
+				}
+				
+				return false;
 			}
 
 			@Override

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/color/internal/ChannelBar.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/color/internal/ChannelBar.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
+import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.utils.Pools;
 import com.kotcrab.vis.ui.Sizes;
 import com.kotcrab.vis.ui.widget.color.BasicColorPicker;
@@ -59,6 +60,7 @@ public class ChannelBar extends ShaderImage {
 		this.mode = mode;
 		this.maxValue = maxValue;
 
+		setTouchable(Touchable.enabled);
 		setValue(value);
 		addListener(changeListener);
 

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/color/internal/Palette.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/color/internal/Palette.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
+import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.utils.Pools;
 import com.kotcrab.vis.ui.Sizes;
 import com.kotcrab.vis.ui.widget.color.BasicColorPicker;
@@ -48,6 +49,8 @@ public class Palette extends ShaderImage {
 		this.style = commons.style;
 		this.sizes = commons.sizes;
 		this.maxValue = maxValue;
+		
+		setTouchable(Touchable.enabled);
 		setValue(0, 0);
 		addListener(listener);
 

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/color/internal/VerticalChannelBar.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/color/internal/VerticalChannelBar.java
@@ -21,6 +21,7 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
+import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.utils.Pools;
 import com.kotcrab.vis.ui.Sizes;
 import com.kotcrab.vis.ui.widget.color.BasicColorPicker;
@@ -42,6 +43,8 @@ public class VerticalChannelBar extends ShaderImage {
 		this.style = commons.style;
 		this.sizes = commons.sizes;
 		this.maxValue = maxValue;
+		
+		setTouchable(Touchable.enabled);
 		setValue(0);
 		addListener(listener);
 


### PR DESCRIPTION
Starting to use vis-ui for a custom editor for our game - really liking it so far.

This commit fixes an issue where the MultiSplitPane was grabbing touches inside the content area and blocking access to other listeners behind it. This adjusts the listener so that it only handles touches that start on the handles.