### PR TITLE
MultiSplitPane should not grab touches inside content

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/MultiSplitPane.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/MultiSplitPane.java
@@ -86,7 +86,11 @@ public class MultiSplitPane extends WidgetGroup {
 
 			@Override
 			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
-				return true;
+				if (getHandleContaining(x, y) != null) {
+					return true;
+				}
+				
+				return false;
 			}
 
 			@Override


### PR DESCRIPTION
Fixing an issue where the MultiSplitPane was grabbing touches inside the content area - it should only consume touches on the handles which is the interaction area of the class. This was blocking other listeners behind the MultiSplitPane.