### PR TITLE
Change parameter type of Error Dialog

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/util/dialog/Dialogs.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/util/dialog/Dialogs.java
@@ -158,7 +158,7 @@ public class Dialogs {
 	}
 
 	/** Dialog with title "Error", provided text and exception stacktrace available after pressing 'Details' button. */
-	public static DetailsDialog showErrorDialog (Stage stage, String text, Exception exception) {
+	public static DetailsDialog showErrorDialog (Stage stage, String text, Throwable exception) {
 		if (exception == null)
 			return showErrorDialog(stage, text, (String) null);
 		else


### PR DESCRIPTION
Change showErrorDialog to accept a throwable rather than an exception for more generic exception handling. The getStackTrace method already accepts a throwable. Should be entirely backwards compatible.